### PR TITLE
Add security reporting option to issue menu

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Report security issue
+    url: https://github.com/debezium/dbz/security/advisories/new
+    about: Please report all security and CVE issues here.
   - name: Debezium Community Support
     url: https://debezium.io/community/
     about: Please ask and answer questions here.


### PR DESCRIPTION
@jpechane I've enabled reporting security vulnerabilities privately for this repository, and this adds a navigation link for users to be redirected to that system rather than these being reported publicly.

We may also want to perform the Security > Policy setup.  What do you think?